### PR TITLE
Removed debug print statement on socket connection.

### DIFF
--- a/tornadio2/session.py
+++ b/tornadio2/session.py
@@ -12,8 +12,6 @@ class ConnectionInfo(object):
         self.cookies = cookies
         self.arguments = arguments
 
-        print arguments
-
     def get_argument(self, name):
         val = self.arguments.get(name)
         if val:


### PR DESCRIPTION
Connection arguments were being printed out every time a connection was created. (probably related to: https://github.com/LearnBoost/socket.io-client/issues/331) 

I just removed the debug line.
