### PR TITLE
EventMagicMeta will now also discover events defined in base classes of cls.

### DIFF
--- a/tornadio2/conn.py
+++ b/tornadio2/conn.py
@@ -60,7 +60,7 @@ class EventMagicMeta(type):
     def __init__(cls, name, bases, attrs):
         # find events, also in bases
         is_event = lambda x: ismethod(x) and hasattr(x, '_event_name')
-        events = getmembers(cls, is_event)
+        events = [(e._event_name, e) for _, e in getmembers(cls, is_event)]
         setattr(cls, '_events', dict(events))
 
         # Call base

--- a/tornadio2/conn.py
+++ b/tornadio2/conn.py
@@ -22,6 +22,7 @@
 """
 import time
 import logging
+from inspect import ismethod, getmembers
 
 from tornadio2 import proto
 
@@ -57,17 +58,10 @@ def event(name_or_func):
 class EventMagicMeta(type):
     """Event handler metaclass"""
     def __init__(cls, name, bases, attrs):
-        # Manage events
-        events = {}
-
-        for a in attrs:
-            attr = getattr(cls, a)
-            name = getattr(attr, '_event_name', None)
-
-            if name:
-                events[name] = attr
-
-        setattr(cls, '_events', events)
+        # find events, also in bases
+        is_event = lambda x: ismethod(x) and hasattr(x, '_event_name')
+        events = getmembers(cls, is_event)
+        setattr(cls, '_events', dict(events))
 
         # Call base
         super(EventMagicMeta, cls).__init__(name, bases, attrs)


### PR DESCRIPTION
We've got a lot of events and we want to factor them into separate classes.

Currently that does not work well with EventMagicMeta because it only looks in attrs, not cls for events. The patch makes EventMagicMeta look for all methods defined on cls with an '_event_name' property, which includes the events defined in additional bases of cls.
