### PR TITLE
Added verify_remote_ip option so that same-IP session checking can be disabled if required

### DIFF
--- a/tests/session_test.py
+++ b/tests/session_test.py
@@ -23,7 +23,8 @@ class DummyServer(object):
                 heartbeat_interval=12,
                 enabled_protocols=['websocket', 'flashsocket', 'xhr-polling',
                                    'jsonp-polling', 'htmlfile'],
-                xhr_polling_timeout=20
+                xhr_polling_timeout=20,
+                verify_remote_ip=True,
         )
         self.stats = stats.StatsCollector()
 
@@ -79,7 +80,7 @@ class DummyConnection(conn.SocketConnection):
     def on_event(self, name, args=[], kwargs=dict()):
         if args:
             self.events.append((name, args))
-            self.emit(name, *args)        
+            self.emit(name, *args)
         else:
             self.events.append((name, kwargs))
             self.emit(name, **kwargs)

--- a/tornadio2/router.py
+++ b/tornadio2/router.py
@@ -58,7 +58,12 @@ DEFAULT_SETTINGS = {
     'global_heartbeats': True,
     # Client timeout adjustment in seconds. If you see your clients disconnect without a
     # reason, increase this value.
-    'client_timeout': 5
+    'client_timeout': 5,
+    # Verify remote IP. May want to disable this for some setups. Some networks send traffic
+    # from same client, different IP each time. If you set this to False, TornadIO will not
+    # check the session ID against IP address. This has consequences for spoofing sessions and
+    # so on, so use with extreme caution.
+    'verify_remote_ip': True,
     }
 
 

--- a/tornadio2/session.py
+++ b/tornadio2/session.py
@@ -145,7 +145,7 @@ class Session(sessioncontainer.SessionBase):
             return False
 
         # If IP address don't match - refuse connection
-        if handler.request.remote_ip != self.remote_ip:
+        if self.server.settings['verify_remote_ip'] and handler.request.remote_ip != self.remote_ip:
             logging.error('Attempted to attach to session %s (%s) from different IP (%s)' % (
                           self.session_id,
                           self.remote_ip,


### PR DESCRIPTION
I ran into problems with networks which send out traffic from a different source IP for each request, and it was causing problems with tornadio2's same-IP session checking.

I introduced the setting verify_remote_ip to disable that checking. If set to True (the default), the checking will happen. If False, the check will be bypassed. I defaulted it to True as disabling the check makes session spoofing easier.
