### PR TITLE
Python 3 compatibility

### DIFF
--- a/examples/multiplexed/multiplexed.py
+++ b/examples/multiplexed/multiplexed.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 from os import path as op
 
 import datetime
@@ -31,7 +33,7 @@ class ChatConnection(SocketConnection):
         return 'User%d' % cls.unique_id
 
     def on_open(self, info):
-        print 'Chat', repr(info)
+        print('Chat', repr(info))
 
         # Give user unique ID
         self.user_name = self.get_username()
@@ -54,7 +56,7 @@ class ChatConnection(SocketConnection):
 
 class PingConnection(SocketConnection):
     def on_open(self, info):
-        print 'Ping', repr(info)
+        print('Ping', repr(info))
 
     def on_message(self, message):
         now = datetime.datetime.now()
@@ -68,7 +70,7 @@ class RouterConnection(SocketConnection):
                      '/ping': PingConnection}
 
     def on_open(self, info):
-        print 'Router', repr(info)
+        print('Router', repr(info))
 
 # Create tornadio server
 MyRouter = TornadioRouter(RouterConnection)

--- a/examples/rpcping/rpcping.py
+++ b/examples/rpcping/rpcping.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 from os import path as op
 
 import datetime
@@ -24,7 +26,7 @@ class SocketIOHandler(web.RequestHandler):
 class PingConnection(SocketConnection):
     @event
     def ping(self, client, text):
-        print 'Got %s from client' % text
+        print('Got %s from client' % text)
 
         now = datetime.datetime.now()
 

--- a/tornadio2/conn.py
+++ b/tornadio2/conn.py
@@ -25,6 +25,7 @@ import logging
 from inspect import ismethod, getmembers
 
 from tornadio2 import proto
+from tornadio2.py2compat import with_metaclass
 
 
 logger = logging.getLogger('tornadio2.conn')
@@ -70,7 +71,7 @@ class EventMagicMeta(type):
         super(EventMagicMeta, cls).__init__(name, bases, attrs)
 
 
-class SocketConnection(object):
+class SocketConnection(with_metaclass(EventMagicMeta, object)):
     """Subclass this class and define at least `on_message()` method to make a Socket.IO
     connection handler.
 
@@ -96,8 +97,6 @@ class SocketConnection(object):
         sock.emit('test', {msg:'Hello World'});
 
     """
-    __metaclass__ = EventMagicMeta
-
     __endpoints__ = dict()
 
     def __init__(self, session, endpoint=None):

--- a/tornadio2/conn.py
+++ b/tornadio2/conn.py
@@ -63,7 +63,7 @@ class EventMagicMeta(type):
     """Event handler metaclass"""
     def __init__(cls, name, bases, attrs):
         # find events, also in bases
-        is_event = lambda x: ismethod(x) and hasattr(x, '_event_name')
+        is_event = lambda x: hasattr(x, '_event_name')
         events = [(e._event_name, e) for _, e in getmembers(cls, is_event)]
         setattr(cls, '_events', dict(events))
 

--- a/tornadio2/flashserver.py
+++ b/tornadio2/flashserver.py
@@ -21,7 +21,6 @@
     Flash Socket policy server implementation. Merged with minor modifications
     from the SocketTornad.IO project.
 """
-from __future__ import with_statement
 
 import socket
 import errno
@@ -64,7 +63,7 @@ class FlashPolicyServer(object):
         while True:
             try:
                 connection, address = sock.accept()
-            except socket.error, ex:
+            except socket.error as ex:
                 if ex[0] not in (errno.EWOULDBLOCK, errno.EAGAIN):
                     raise
                 return

--- a/tornadio2/persistent.py
+++ b/tornadio2/persistent.py
@@ -144,7 +144,7 @@ class TornadioWebSocketHandler(WebSocketHandler):
 
         try:
             self.session.raw_message(message)
-        except Exception, ex:
+        except Exception as ex:
             logger.error('Failed to handle message: ' + traceback.format_exc(ex))
 
             # Close session on exception

--- a/tornadio2/polling.py
+++ b/tornadio2/polling.py
@@ -22,7 +22,10 @@
 """
 import time
 import logging
-import urllib
+try:
+    from urllib import unquote_plus  # Python 2
+except ImportError:
+    from urllib.parse import unquote_plus  # Python 3
 
 from tornado.web import HTTPError, asynchronous
 
@@ -295,7 +298,7 @@ class TornadioJSONPHandler(TornadioXHRPollingHandler):
                 raise HTTPError(403)
 
             # Grab data
-            data = urllib.unquote_plus(data[2:]).decode('utf-8')
+            data = unquote_plus(data[2:]).decode('utf-8')
 
             # If starts with double quote, it is json encoded (socket.io workaround)
             if data.startswith(u'"'):

--- a/tornadio2/py2compat.py
+++ b/tornadio2/py2compat.py
@@ -1,0 +1,16 @@
+def with_metaclass(meta, *bases):
+    """
+    Helper for adding a metaclass to a class definition compatible with Python 2
+    and 3.
+
+    See Armin Ronacher's post for more information:
+    http://lucumr.pocoo.org/2013/5/21/porting-to-python-3-redux/
+    """
+    class metaclass(meta):
+        __call__ = type.__call__
+        __init__ = type.__init__
+        def __new__(cls, name, this_bases, d):
+            if this_bases is None:
+                return type.__new__(cls, name, (), d)
+            return meta(name, bases, d)
+    return metaclass('temporary_class', None, {})

--- a/tornadio2/router.py
+++ b/tornadio2/router.py
@@ -87,7 +87,7 @@ class HandshakeHandler(preflight.PreflightHandler):
 
             # TODO: Fix heartbeat timeout. For now, it is adding 5 seconds to the client timeout.
             data = '%s:%d:%d:%s' % (
-                sess.session_id,
+                sess.session_id.decode('utf-8'),
                 # TODO: Fix me somehow a well. 0.9.2 will drop connection is no
                 # heartbeat was sent over
                 settings['heartbeat_interval'] + settings['client_timeout'],

--- a/tornadio2/server.py
+++ b/tornadio2/server.py
@@ -99,7 +99,7 @@ class SocketServer(HTTPServer):
                     io_loop=io_loop,
                     port=flash_policy_port,
                     policy_file=flash_policy_file)
-            except Exception, ex:
+            except Exception as ex:
                 logger.error('Failed to start Flash policy server: %s', ex)
 
         if auto_start:

--- a/tornadio2/session.py
+++ b/tornadio2/session.py
@@ -21,7 +21,10 @@
     Active TornadIO2 connection session.
 """
 
-import urlparse
+try:
+    from urlparse import urlparse  # Python 2
+except ImportError:
+    from urllib.parse import urlparse  # Python 3
 import logging
 
 
@@ -289,7 +292,7 @@ class Session(sessioncontainer.SessionBase):
         `url`
             socket.io endpoint URL.
         """
-        urldata = urlparse.urlparse(url)
+        urldata = urlparse(url)
 
         endpoint = urldata.path
 
@@ -404,7 +407,7 @@ class Session(sessioncontainer.SessionBase):
                 # in args
                 if len(args) == 1 and isinstance(args[0], dict):
                     # Fix for the http://bugs.python.org/issue4978 for older Python versions
-                    str_args = dict((str(x), y) for x, y in args[0].iteritems())
+                    str_args = dict((str(x), y) for x, y in args[0].items())
 
                     ack_response = conn.on_event(event['name'], kwargs=str_args)
                 else:
@@ -429,7 +432,7 @@ class Session(sessioncontainer.SessionBase):
                 logger.error('Incoming error: %s' % msg_data)
             elif msg_type == proto.NOOP:
                 pass
-        except Exception, ex:
+        except Exception as ex:
             logger.exception(ex)
 
             # TODO: Add global exception callback?

--- a/tornadio2/sessioncontainer.py
+++ b/tornadio2/sessioncontainer.py
@@ -31,8 +31,9 @@ from random import random
 def _random_key():
     """Return random session key"""
     i = md5()
-    i.update('%s%s' % (random(), time()))
-    return i.hexdigest()
+    # Python 3 requires bytes not string, hence the encode
+    i.update(('%s%s' % (random(), time())).encode('utf-8'))
+    return i.hexdigest().encode('utf-8')
 
 
 class SessionBase(object):
@@ -71,8 +72,13 @@ class SessionBase(object):
         """Triggered when object was expired or deleted."""
         pass
 
+    # Python 2
     def __cmp__(self, other):
         return cmp(self.expiry_date, other.expiry_date)
+
+    # Python 3
+    def __lt__(self, other):
+        return self.expiry_date < other.expiry_date
 
     def __repr__(self):
         return '%f %s %d' % (getattr(self, 'expiry_date', -1),


### PR DESCRIPTION
This fixes issue #48. It was surprisingly straightforward.

A few things of note:
0. The aim was to have a single codebase that's compatible with both major versions.
1. It takes advantage of the py3 syntax backports into 2.6 and 2.7 as well as the reintroduced `u'string'` literals in 3.3. As such, the code is not compatible with 2.5, 3.1 and 3.2. If that's alright with the community, I'd like to keep it that way because it makes it much easier to maintain. If it is a problem, we should come up with a consensus on the supported versions and I shall attempt to update this.
2. I didn't get to port the tests yet. That's to come next week if there's an interest the port. I have updated and tested the examples, though, and they work.
3. Related to that, the "gen" and "ssl_transports" examples didn't work for me out of the box on `master` so I don't test them on the  `python3` branch either. I'll look into it next week to see if there are genuine bugs or it's just an issue with my setup.

I tried to follow Armin Ronacher's suggestions:
http://lucumr.pocoo.org/2013/5/21/porting-to-python-3-redux/

Please do try it out and let me know if you have any issues or concerns over the code.
